### PR TITLE
Use vscode.ExtensionContext.globalStoragePath to store persistent set…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "activationEvents": [
     "*"
   ],
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ],
   "main": "./out/src/extension",
   "contributes": {
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import Settings from './lib/persistent-settings';
 import {changelogMessage} from './lib/messages';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-    const settings = new Settings(vscode);
+    const settings = new Settings(vscode, context.globalStoragePath);
     // const materialThemeInstalled = await isMaterialTheme(await getCurrentThemeID());
 
     // if (settings.isFirstInstall() && !materialThemeInstalled && await installationMessage()) {

--- a/src/lib/persistent-settings.ts
+++ b/src/lib/persistent-settings.ts
@@ -1,7 +1,8 @@
 import {join} from 'path';
-import {existsSync, writeFileSync, unlinkSync} from 'fs';
+import {existsSync, writeFileSync, unlinkSync, mkdirSync} from 'fs';
 import {SemVer, lt} from 'semver';
 import * as os from 'os';
+import * as path from 'path';
 
 import {IPersistentSettings, ISettings, IExtensionSettings, IState} from '../../typings/interfaces/persistent-settings';
 import {IVSCode} from '../../typings/interfaces/vscode';
@@ -12,7 +13,7 @@ export default class PersistentSettings implements IPersistentSettings {
   private settings: ISettings;
   private defaultState: IState;
 
-  constructor(private vscode: IVSCode) {
+  constructor(private vscode: IVSCode, private globalStoragePath: string) {
     this.settings = this.getSettings();
     this.defaultState = {
       version: '0.0.0'
@@ -27,29 +28,46 @@ export default class PersistentSettings implements IPersistentSettings {
     const vscodeVersion = new SemVer(this.vscode.version).version;
     const isWin = /^win/.test(process.platform);
 
-    const vscodePath = this.vscodePath();
-    const vscodeAppName = this.vscodeAppName(isInsiders, isOSS, isDev);
-    const vscodeAppUserPath = join(vscodePath, vscodeAppName, 'User');
-    const persistentSettingsFilePath = join(vscodeAppUserPath, FILES.persistentSettings);
-
-    const {version} = getPackageJson();
+    const { version } = getPackageJson();
 
     const extensionSettings: IExtensionSettings = {
       version
     };
 
+    const persistentSettingsFilePath = path.join(this.globalStoragePath, 'settings.json')
     this.settings = {
       isDev,
       isOSS,
       isInsiders,
       isWin,
       vscodeVersion,
-      vscodeAppUserPath,
       persistentSettingsFilePath,
       extensionSettings
     };
 
+    if (!existsSync(this.globalStoragePath)) {
+      mkdirSync(this.globalStoragePath);
+    }
+
+    this.migratePersistentSettings(isInsiders, isOSS, isDev);
+
     return this.settings;
+  }
+
+  getOldPersistentSettingsPath(isInsiders: boolean, isOSS: boolean, isDev: boolean): string {
+    const vscodePath = this.vscodePath();
+    const vscodeAppName = this.vscodeAppName(isInsiders, isOSS, isDev);
+    const vscodeAppUserPath = join(vscodePath, vscodeAppName, 'User');
+    return join(vscodeAppUserPath, FILES.persistentSettings);
+  }
+
+  migratePersistentSettings(isInsiders: boolean, isOSS: boolean, isDev: boolean) {
+    const oldPersistentSettingsFilePath = this.getOldPersistentSettingsPath(isInsiders, isOSS, isDev);
+    if (existsSync(oldPersistentSettingsFilePath)) {
+      let oldState = require(oldPersistentSettingsFilePath) as IState;
+      this.setState(oldState);
+      unlinkSync(oldPersistentSettingsFilePath);
+    }
   }
 
   getState(): IState {

--- a/src/lib/persistent-settings.ts
+++ b/src/lib/persistent-settings.ts
@@ -49,7 +49,7 @@ export default class PersistentSettings implements IPersistentSettings {
       mkdirSync(this.globalStoragePath);
     }
 
-    this.migratePersistentSettings(isInsiders, isOSS, isDev);
+    this.migrateOldPersistentSettings(isInsiders, isOSS, isDev);
 
     return this.settings;
   }
@@ -61,7 +61,7 @@ export default class PersistentSettings implements IPersistentSettings {
     return join(vscodeAppUserPath, FILES.persistentSettings);
   }
 
-  migratePersistentSettings(isInsiders: boolean, isOSS: boolean, isDev: boolean) {
+  migrateOldPersistentSettings(isInsiders: boolean, isOSS: boolean, isDev: boolean) {
     const oldPersistentSettingsFilePath = this.getOldPersistentSettingsPath(isInsiders, isOSS, isDev);
     if (existsSync(oldPersistentSettingsFilePath)) {
       let oldState = require(oldPersistentSettingsFilePath) as IState;

--- a/test/lib/persistent-settings.test.ts
+++ b/test/lib/persistent-settings.test.ts
@@ -2,17 +2,21 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {expect} from 'chai';
 import * as sinon from 'sinon';
 import {vscode} from '../utils';
 import PersistentSettings from '../../src/lib/persistent-settings';
 import {IState} from '../../typings/interfaces/persistent-settings';
 
+const globalStoragePath = path.join(os.tmpdir(), 'vsc-material-theme');
+
 describe('PersistentSettings: tests', function (): void {
   context('ensures that', function (): void {
     context('getting the settings', function (): void {
       it('more than once, returns the same instance', function (): void {
-        const persistentSettings = new PersistentSettings(vscode);
+        const persistentSettings = new PersistentSettings(vscode, globalStoragePath);
         const settings = persistentSettings.getSettings();
         const settingsAgain = persistentSettings.getSettings();
         expect(settings).to.be.an.instanceOf(Object);
@@ -20,20 +24,10 @@ describe('PersistentSettings: tests', function (): void {
         expect(settingsAgain).to.be.deep.equal(settings);
       });
 
-      it('detects correctly if it is in portable mode', function (): void {
-        const sandbox = sinon
-          .createSandbox()
-          .stub(process, 'env')
-          .value({VSCODE_PORTABLE: '/PathToPortableInstallationDir/data'});
-        const settings = new PersistentSettings(vscode).getSettings();
-        expect(settings.vscodeAppUserPath).to.match(/user-data/);
-        sandbox.restore();
-      });
-
       context('returns the correct name when application is the', function (): void {
         it('`Code - Insiders`', function (): void {
           vscode.env.appName = 'Visual Studio Code - Insiders';
-          const settings = new PersistentSettings(vscode).getSettings();
+          const settings = new PersistentSettings(vscode, globalStoragePath).getSettings();
           expect(settings.isInsiders).to.be.true;
           expect(settings.isOSS).to.be.false;
           expect(settings.isDev).to.be.false;
@@ -41,7 +35,7 @@ describe('PersistentSettings: tests', function (): void {
 
         it('`Code`', function (): void {
           vscode.env.appName = 'Visual Studio Code';
-          const settings = new PersistentSettings(vscode).getSettings();
+          const settings = new PersistentSettings(vscode, globalStoragePath).getSettings();
           expect(settings.isInsiders).to.be.false;
           expect(settings.isOSS).to.be.false;
           expect(settings.isDev).to.be.false;
@@ -71,7 +65,7 @@ describe('PersistentSettings: tests', function (): void {
     let sandbox: sinon.SinonSandbox;
 
     beforeEach(() => {
-      persistentSettings = new PersistentSettings(vscode);
+      persistentSettings = new PersistentSettings(vscode, globalStoragePath);
       sandbox = sinon.createSandbox();
     });
 

--- a/typings/interfaces/persistent-settings.d.ts
+++ b/typings/interfaces/persistent-settings.d.ts
@@ -7,7 +7,6 @@ export interface ISettings {
   isInsiders: boolean;
   isOSS: boolean;
   isDev: boolean;
-  vscodeAppUserPath: string; // path to the vscode app user directory
   persistentSettingsFilePath: string;
   vscodeVersion: string;
   extensionSettings: IExtensionSettings;


### PR DESCRIPTION
Addresses https://github.com/material-theme/vsc-material-theme/issues/452

- uses the API `vscode.ExtensionContext.globalStoragePath` for the location of global extension settings. Using this API ensures that the extension can run in both a UI extension host and a remote extension host.

- the contents of the old persistent settings is migrated to the new storage location.

- changed the `extensionKind` to `"["ui", "workspace"]"` since the extension now can also run in the UI extension Host.

- Removed the VSCodeAppUserPath setting (and the portable mode test). No longer needed since an API is used to determine the storage location.