### PR TITLE
Fix invalid file names introduced in v2.3

### DIFF
--- a/src/icons/partials/fileNames.js
+++ b/src/icons/partials/fileNames.js
@@ -147,6 +147,6 @@
   "favicon.ico": "_file_favicon",
   "mix.lock": "_file_elixir-lock",
   "now.json": "_file_now",
-  ".next.config.js": "_file_nextjs",
-  ".next.config.mjs": "_file_nextjs"
+  "next.config.js": "_file_nextjs",
+  "next.config.mjs": "_file_nextjs"
 },


### PR DESCRIPTION
The file names shouldn't have a `.` at the beginning, as of https://nextjs.org/docs/api-reference/next.config.js/introduction.

I guess the mistake was introduced by me as my issue ( #189 ) had a typo. **I'm sorry for that.**