### PR TITLE
feat: add `.eslintrc.cjs` to eslint file names

### DIFF
--- a/src/icons/partials/fileNames.js
+++ b/src/icons/partials/fileNames.js
@@ -100,6 +100,7 @@
   ".eslintrc": "_file_eslint",
   ".eslintignore": "_file_eslint",
   ".eslintrc.js": "_file_eslint",
+  ".eslintrc.cjs": "_file_eslint",
   ".eslintrc.json": "_file_eslint",
   ".eslintrc.yml": "_file_eslint",
   ".eslintrc.yaml": "_file_eslint",


### PR DESCRIPTION
The `.eslintrc.cjs` file is used to configure eslint in ESM projects. [Docs](https://eslint.org/docs/latest/user-guide/configuring/configuration-files)