### PR TITLE
feat: add vite.config.mts to vite file names

### DIFF
--- a/src/icons/partials/fileNames.js
+++ b/src/icons/partials/fileNames.js
@@ -178,6 +178,7 @@
   "vite.config.cjs": "_file_vite",
   "vite.config.mjs": "_file_vite",
   "vite.config.ts": "_file_vite",
+  "vite.config.mts": "_file_vite",
   "postcss.config.cjs": "_file_postcss",
   "postcss.config.js": "_file_postcss",
   "postcss.config.mjs": "_file_postcss",


### PR DESCRIPTION
The `vite.config.mts` file is also accepted by following the [docs](https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated).